### PR TITLE
Release MAUI v2.1.0 / Android v10.3.0 / iOS 12.3.0

### DIFF
--- a/ExampleAppMAUI/ExampleAppMAUI.csproj
+++ b/ExampleAppMAUI/ExampleAppMAUI.csproj
@@ -75,7 +75,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="iProov.NET.MAUI" Version="2.0.2" />
+	  <PackageReference Include="iProov.NET.MAUI" Version="2.1.0" />
 	</ItemGroup>
 	<ItemGroup>
 	  <ProjectReference Include="..\APIClient\APIClient.csproj" />

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The **iProov.NET.MAUI** library is available at [nugets.org](https://www.nuget.o
 
  ```
  <ItemGroup>
-   <PackageReference Include="iProov.NET.MAUI" Version="2.0.2" />
+   <PackageReference Include="iProov.NET.MAUI" Version="2.1.0" />
  </ItemGroup>
  ```
 


### PR DESCRIPTION
Updated wrappers to use the latest native SDKs:
* iProov.NET.MAUI v2.1.0, which depends on
    * iProov.NET.Android v10.3.0
    * iProov.NET.iOS v12.3.0